### PR TITLE
Added MaybeSyncBlock to Syntax, needed for pattern matching in generators

### DIFF
--- a/rebel-core/examples/account/extended/MultiCurrencyAccount.ebl
+++ b/rebel-core/examples/account/extended/MultiCurrencyAccount.ebl
@@ -1,0 +1,29 @@
+module account.extended.MultiCurrencyAccount
+
+import account.extended.MultiCurrencyAccountLib
+
+specification MultiCurrencyAccount {
+    fields {
+        accountNumber: IBAN @key
+        balance: map[Currency : Integer]
+    }
+    events {
+        openAccount[]
+        closeAccount[]
+        openCurrency[]
+        closeCurrency[]
+        deposit[]
+        withdraw[]
+    }
+    
+    invariants {
+    }
+    
+    lifeCycle {
+        initial init -> opened: openAccount
+        opened -> opened: openCurrency, closeCurrency, deposit, withdraw
+        opened -> closed: closeAccount
+        final closed  
+    }
+    
+}

--- a/rebel-core/examples/account/extended/MultiCurrencyAccountLib.ebl
+++ b/rebel-core/examples/account/extended/MultiCurrencyAccountLib.ebl
@@ -1,0 +1,48 @@
+module account.extended.MultiCurrencyAccountLib
+
+import account.extended.MultiCurrencyAccount
+
+event openAccount() {}
+
+event openCurrency(currency : Currency) {
+    preconditions {
+       not (currency in this.balance);
+    }
+    postconditions {
+       currency in new this.balance;
+    }
+}
+
+event closeCurrency(currency : Currency) {
+    preconditions {
+       currency in this.balance;
+    }
+    postconditions {
+       not (currency in new this.balance);
+    }
+}
+
+event deposit(amount : Money) {
+    preconditions { 
+        amount.cur in this.balance;
+    }
+    postconditions {
+        new this.balance[amount.cur] == this.balance[amount.cur] + amount.amount;
+    }
+}
+
+event withdraw(amount : Money) {
+    preconditions { 
+        amount.cur in this.balance;
+    }
+    postconditions {
+        new this.balance[amount.cur] == this.balance[amount.cur] - amount.amount;
+    }
+}
+
+
+event closeAccount() {
+    preconditions {
+        // this.balance == ();
+    }
+}

--- a/rebel-core/examples/simple_transaction_extended/Account.ebl
+++ b/rebel-core/examples/simple_transaction_extended/Account.ebl
@@ -1,0 +1,42 @@
+module simple_transaction_extended.Account
+
+import simple_transaction_extended.Library
+
+@doc {
+	This is a specification of a toy Account.
+	The account can be opened, blocked and closed and can never be overdrawn.
+}
+specification Account {
+	fields {
+		accountNumber: IBAN @key
+		customerId: Integer @ref=Customer
+		balance: Money
+	}
+	
+	
+	events {
+		openAccount[minimalDeposit = EUR 50.00]
+		withdraw[]   
+		deposit[] 
+		interest[]  
+		block[]  
+		unblock[]  
+		close[]
+	} 
+	
+	invariants {
+		positiveBalance
+	}
+	
+	lifeCycle {
+		initial init -> opened: openAccount
+		
+		opened -> opened: withdraw, deposit, interest
+			     -> blocked: block
+			     -> closed: close
+		
+		blocked -> opened: unblock
+		
+		final closed		
+	}
+}

--- a/rebel-core/examples/simple_transaction_extended/Customer.ebl
+++ b/rebel-core/examples/simple_transaction_extended/Customer.ebl
@@ -1,0 +1,33 @@
+module simple_transaction_extended.Customer
+
+import simple_transaction_extended.Library
+
+@doc {
+    This is a specification of a toy User.
+    A user can have multiple accounts.
+}
+specification Customer {
+    fields {
+        id: Integer @key
+        firstName: String
+        lastName: String
+        country: String      
+    }
+    
+    events {
+        createCustomer[]
+        onboardCustomer[]
+        declineCustomer[]
+        deleteCustomer[]
+    } 
+
+    lifeCycle {
+        initial init -> createdCustomer: createCustomer
+        
+        createdCustomer -> onboardedCustomer: onboardCustomer
+                    -> declinedCustomer:  declineCustomer
+        onboardedCustomer -> deletedCustomer: deleteCustomer      
+        final declinedCustomer
+        final deletedCustomer
+    }
+}

--- a/rebel-core/examples/simple_transaction_extended/Library.ebl
+++ b/rebel-core/examples/simple_transaction_extended/Library.ebl
@@ -1,0 +1,156 @@
+module simple_transaction_extended.Library
+
+import simple_transaction_extended.Account
+import simple_transaction_extended.Customer
+ 
+//import simple_transaction_extended.Reservation
+
+@doc { 	
+	Opening an account needs a valid IBAN and some initial deposit. 
+} 
+event openAccount[minimalDeposit: Money = EUR 0.00](initialDeposit: Money, customerId: Integer) {
+	preconditions {
+		initialDeposit >= minimalDeposit;
+		initialized Customer[customerId];
+	}
+	postconditions {
+		new this.balance == initialDeposit;
+		new this.customerId == customerId;
+	} 
+} 
+@doc {
+	Withdraw money from the account.
+}
+event withdraw(amount: Money) {
+	preconditions {
+		amount > EUR 0.00;
+		
+		this.balance - amount >= EUR 0.00;
+	}
+	postconditions {
+		new this.balance == this.balance - amount;
+	}
+	//sync { 
+	//  Reservation[this.accountNumber].check(amount); 
+	//}
+}
+
+@doc {
+	Deposit money on the account. 
+}
+event deposit(amount: Money) {
+	preconditions {
+		amount > EUR 0.00;
+	}
+	postconditions {
+		new this.balance == this.balance + amount;
+	}
+}
+
+@doc {
+	Block the account for withdrawals and deposits.
+}
+event block() {}
+
+@doc {
+	Unblock the account so that withdrawals and deposits can happen again.
+}
+event unblock() {}
+
+@doc {
+	Close the account.
+}
+
+event close() { 
+	preconditions {
+		this.balance == EUR 0.00;
+	}
+}	
+
+function singleInterest(balance: Money, interest: Percentage): Money =  balance * interest;
+
+event interest[maxInterest: Percentage = 10%](currentInterest: Percentage) {
+  preconditions {
+    currentInterest <= maxInterest; 
+    currentInterest > 0%;
+  }
+  postconditions {
+    new this.balance == this.balance + singleInterest(this.balance, currentInterest);
+  }
+}
+
+@doc {
+	The balance should always be positive
+}
+invariant positiveBalance {
+	this.balance >= EUR 0.00;
+}
+
+@doc {
+	Start a new transaction.
+	The transaction can only be booked on the specified date.
+}
+event start(amount: Money, from: IBAN, to: IBAN) {//, bookOn: Date) {
+	preconditions {
+		@doc{From account must exist.}
+		initialized Account[from];
+		@doc{To account must exist.}
+		initialized Account[to];
+		
+		@doc{From and to account should differ}
+		to != from;
+		
+		amount > EUR 0.00;
+		amount.currency == EUR;
+	}
+	postconditions {
+		new this.amount == amount;
+		new this.from == from;
+		new this.to == to;
+		
+		//@doc{The created on date is set to the current date}
+		//new this.createdOn == now;
+		
+		//new this.bookedOn == bookOn;
+	}
+}
+
+@doc{
+	Book the transaction.
+	The transaction can only be booked if today is the set book date
+}
+event book() {
+	preconditions {
+		//this.bookedOn == now.date;	
+	} 
+	sync { 
+		Account[this.from].withdraw(this.amount);
+		Account[this.to].deposit(this.amount);  
+	}
+}
+
+@doc{
+	Fails the transaction.
+	If it is not possible to book the transaction (not enough money in account, past the bookOn date, etc) the transaction can be failed.
+	No money is transfered between the accounts
+}
+event fail() {}
+
+event createCustomer(firstName: String, lastName: String, country : String) {
+    postconditions {
+        new this.firstName == firstName;
+        new this.lastName == lastName;
+        new this.country == country;
+    }
+}
+event onboardCustomer[unacceptedCountries : set[String] = { "Syria", "Iran" }]() {
+    preconditions {
+        // not (this.country in unacceptedCountries);
+    }
+}
+event declineCustomer() {
+
+}
+event deleteCustomer() { 
+    // TODO cant happen whilst accounts have balance
+}

--- a/rebel-core/examples/simple_transaction_extended/Transaction.ebl
+++ b/rebel-core/examples/simple_transaction_extended/Transaction.ebl
@@ -1,0 +1,33 @@
+module simple_transaction_extended.Transaction
+
+import simple_transaction_extended.Library
+import simple_transaction_extended.Account
+
+@doc{
+	This is a specification of a toy Transaction.
+	Via a transaction money can be transfered between two accounts
+}
+specification Transaction {
+	fields {
+		id: Integer @key
+		amount: Money 
+		from: IBAN @ref=Account
+		to: IBAN @ref=Account 
+		//createdOn: DateTime
+		//bookedOn: Date
+	}
+	  
+	events {   
+		start[]  
+		book[]  
+		fail[]  
+	}
+	
+	lifeCycle {
+		initial uninit -> validated: start 
+		validated    -> booked: book 
+					-> failed: fail
+		final booked
+		final failed
+	}	
+}

--- a/rebel-core/src/lang/Builder.rsc
+++ b/rebel-core/src/lang/Builder.rsc
@@ -35,7 +35,7 @@ alias UsedBy = set[loc];
 
 private str buildDir = "bin";
 
-loc getOutputLoc(loc srcFile)  = |<srcFile.scheme>://<srcFile.authority>/<buildDir>/rebel|;
+loc getOutputLoc(loc srcFile)  = srcFile.scheme == "project" ? |<srcFile.scheme>://<srcFile.authority>/<buildDir>/rebel| : (|home:///<buildDir>/rebel/| + srcFile.path);
 
 tuple[set[Message], Maybe[Built]] load(loc modLoc, 
   loc outputDir = getOutputLoc(modLoc), 

--- a/rebel-core/src/lang/Syntax.rsc
+++ b/rebel-core/src/lang/Syntax.rsc
@@ -30,7 +30,9 @@ syntax LibraryModule
   
 // Library rules
 
-syntax EventDef = Annotations annos "event" FullyQualifiedVarName name EventConfigBlock? configParams "(" {Parameter ","}* transitionParams")" "{" Preconditions? pre Postconditions? post SyncBlock? sync "}";
+syntax EventDef = Annotations annos "event" FullyQualifiedVarName name EventConfigBlock? configParams "(" {Parameter ","}* transitionParams")" "{" Preconditions? pre Postconditions? post MaybeSyncBlock sync "}";
+
+syntax MaybeSyncBlock = SyncBlock?;
 
 syntax EventConfigBlock = "[" {Parameter ","}+ params "]";
 
@@ -88,7 +90,7 @@ syntax SyncExpr
 syntax Statement  
 	= bracket "(" Statement ")"
 	| "case" Expr "{" Case+ cases "}" ";"
-	| Annotations annos Expr ";"
+	| Annotations annos Expr expr ";"
 	;  
   	
 syntax Case = Literal lit "=\>" Statement stat;

--- a/rebel-core/src/lang/TypeInferrer.rsc
+++ b/rebel-core/src/lang/TypeInferrer.rsc
@@ -79,6 +79,7 @@ Type resolveAddition((Type)`Integer`,   (Type)`Integer`) = (Type)`Integer`;
 Type resolveAddition((Type)`Date`,      (Type)`Date`)    = (Type)`Term`;
 Type resolveAddition((Type)`Date`,      (Type)`Term`)    = (Type)`Date`;
 Type resolveAddition((Type)`Money`,     (Type)`Money`)   = (Type)`Money`;
+Type resolveAddition((Type)`String`,     (Type)`String`)   = (Type)`String`;
 default Type resolveAddition(Type _, Type _)             = (Type)`$$INVALID_TYPE$$`;
 
 // Multiply


### PR DESCRIPTION
Can this be added to the grammar? This is required since we can use `SyncBlock?` as a type in Rascal. See http://stackoverflow.com/questions/41279275/how-can-i-contruct-a-x-concrete-syntax-value for details.

I'm not sure though what impact this has on all the other Rebel code.