### PR TITLE
inlinedEvents should be events from the ExtendedSyntax

### DIFF
--- a/rebel-core/src/analysis/SimulationHelper.rsc
+++ b/rebel-core/src/analysis/SimulationHelper.rsc
@@ -160,7 +160,7 @@ str findStep(set[Built] allSpecs, str entity, str stepLabel) = "<evnt.name>"
   when  Built b <- allSpecs, 
         b has normalizedMod, 
         entity == "<b.normalizedMod.modDef.fqn>",
-        EventDef evnt <- b.normalizedMod.spec.inlinedEvents.events,
+        EventDef evnt <- b.normalizedMod.spec.events.events,
         /(Statement)`new <Expr spc>[<Expr id>]._step == <Int i>;` := evnt.post,
         stepLabel == "<i>";
 default str findStep(set[Built] allSpecs, str entity, str stepLabel) = "?";


### PR DESCRIPTION
The ExtendedSyntax doesn't have an inlinedEvents. Probably this happened during changing the overloaded labels in the ExtendedSyntax: 7fc498ca6441d97a292dcf95b8969e67d2623a78.