### PR TITLE
Implement sort conversion for boolean type

### DIFF
--- a/rebel-core/src/analysis/CommonAnalysisFunctions.rsc
+++ b/rebel-core/src/analysis/CommonAnalysisFunctions.rsc
@@ -485,6 +485,7 @@ Sort translateSort((Type)`Integer`) = \integer();
 Sort translateSort((Type)`Frequency`) = custom("Frequency");
 Sort translateSort((Type)`Percentage`) = custom("Percentage");
 Sort translateSort((Type)`String`) = \string();
+Sort translateSort((Type)`Boolean`) = \boolean();
 
 
 default Sort translateSort(Type t) { throw "Sort conversion for <t> not yet implemented"; }

--- a/rebel-core/src/analysis/SimulationHelper.rsc
+++ b/rebel-core/src/analysis/SimulationHelper.rsc
@@ -160,7 +160,7 @@ str findStep(set[Built] allSpecs, str entity, str stepLabel) = "<evnt.name>"
   when  Built b <- allSpecs, 
         b has normalizedMod, 
         entity == "<b.normalizedMod.modDef.fqn>",
-        EventDef evnt <- b.normalizedMod.spec.inlinedEvents.events,
+        EventDef evnt <- b.normalizedMod.spec.events.events,
         /(Statement)`new <Expr spc>[<Expr id>]._step == <Int i>;` := evnt.post,
         stepLabel == "<i>";
 default str findStep(set[Built] allSpecs, str entity, str stepLabel) = "?";


### PR DESCRIPTION
A boolean field from a specification isn’t supported. When this field is translated, it will throw: Sort conversion for Boolean not yet implemented.